### PR TITLE
Allow Cloudflare analytics

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -54,10 +54,10 @@ module.exports = function(eleventyConfig) {
     const headersPath = '_site/_headers';
     if (fs.existsSync(headersPath)) {
       let headers = fs.readFileSync(headersPath, 'utf-8');
-      const scriptSrc = hashes.size > 0 ? ` script-src ${[...hashes].join(' ')};` : '';
+      const scriptSrc = hashes.size > 0 ? [...hashes].join(' ') : '';
       headers = headers.replace(
-        /Content-Security-Policy:.*$/m,
-        `Content-Security-Policy: default-src 'self';${scriptSrc}`
+        "[[inline-scripts]]",
+        scriptSrc
       );
       fs.writeFileSync(headersPath, headers);
     }

--- a/_headers.njk
+++ b/_headers.njk
@@ -6,7 +6,7 @@ eleventyExcludeFromCollections: true
 
 # Headers for all sites
 /
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com;
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com [[inline-scripts]];
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer

--- a/_headers.njk
+++ b/_headers.njk
@@ -6,7 +6,7 @@ eleventyExcludeFromCollections: true
 
 # Headers for all sites
 /
-  Content-Security-Policy: default-src 'self';
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com;
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer


### PR DESCRIPTION
Generally, I have been questioning the use of analytics scripts for small sites like this, and have removed old Google Analytics scripts accordingly.  While larger sites may benefit from knowing their users, something like this humble blog needs it less.  For the moment, I want to experiment to see if it is worth utilizing this service, primarily to see what value it may give to a small blog.  I prefer to keep it all within Cloudflare, instead of introducing new third-parties into the chain.  I am making this PR as a bit of a record, in case there are comments on the implementation.  